### PR TITLE
[tmux] set default terminal

### DIFF
--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -71,6 +71,9 @@ set-option -g focus-events on
 # automatically renumber windows upon closing them
 set-option -g renumber-windows on
 
+# set default terminal
+set-option -g default-terminal 'screen-256color'
+
 # Copy and paste
 bind P paste-buffer
 # Enable vim copy paste mode


### PR DESCRIPTION
By default, if not set, `default-terminal` is set to `tmux-256color`.
This PR sets it to `screen-256color` for compatibility with other systems.
